### PR TITLE
Fix broken install_url in Github Actions example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
         fetch-depth: 0
     - uses: cachix/install-nix-action@v11
       with:
-        install_url: https://github.com/numtide/nix-flakes-installer/releases/download//install
+        install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-3.0pre20201007_5257a25/install
         # Configure Nix to enable flakes
         extra_nix_config: |
           experimental-features = nix-command flakes

--- a/README.md.erb
+++ b/README.md.erb
@@ -33,7 +33,7 @@ jobs:
         fetch-depth: 0
     - uses: cachix/install-nix-action@v11
       with:
-        install_url: https://github.com/numtide/nix-flakes-installer/releases/download/<% release_id %>/install
+        install_url: https://github.com/numtide/nix-flakes-installer/releases/download/<%= release_id %>/install
         # Configure Nix to enable flakes
         extra_nix_config: |
           experimental-features = nix-command flakes


### PR DESCRIPTION
In the README.md template the expression tag is missing an equals sign
causing it to be treated as a scriptlet and not producing any text:

```erb
    install_url: https://github.com/numtide/nix-flakes-installer/releases/download/<% release_id %>/install
```

Therefore the tag name of the release in the URL wound up empty.

Fixes the issue by adding the equals sign.